### PR TITLE
Remoção de obrigação de passar o parametro devedor como objeto

### DIFF
--- a/src/methods/pix.js
+++ b/src/methods/pix.js
@@ -78,7 +78,7 @@ export class PixMethods extends CobrancasMethods {
      *   calendario: {
      *     expiracao: number
      *   },
-     *   devedor: {
+     *   devedor?: {
      *     cpf?: string,
      *     cnpj?: string,
      *     nome: string


### PR DESCRIPTION
A EfiPay obriga que o devedor seja passado na sdk, porem pela api se você quiser que não precise passar o CPF ou CNPJ você precisa não passar o objeto de devedor.

Então atualmente nas aplicações utilizamos: devedor: undefined as any se for o caso do typescript, então fazendo com que seja opcional resolve o problema.