### PR TITLE
fix: move registro do interceptor axios de req() para constructor

### DIFF
--- a/src/lib/endpoints.js
+++ b/src/lib/endpoints.js
@@ -13,6 +13,32 @@ class Endpoints {
 		this.constants = constants
 		this.authError = null
 		this.axiosInstance = axios.create()
+
+		// Request interceptor - registered once in constructor to prevent memory leak
+		this.axiosInstance.interceptors.request.use(
+			async (config) => {
+				if (!this.auth || this.isExpired()) {
+					this.authError = await this.authenticate()
+				}
+
+				config.headers = {
+					...config.headers,
+					Authorization: `Bearer ${this.auth.access_token}`,
+					'x-skip-mtls-checking': !this.options.validateMtls
+				}
+				if (this.options.partner_token) {
+					config.headers['partner-token'] = this.options.partner_token
+				}
+				if (this.baseUrl == this.constants.APIS.OPENFINANCE.URL.PRODUCTION || this.baseUrl == this.constants.APIS.OPENFINANCE.URL.SANDBOX) {
+					config.headers['x-idempotency-key'] = randomstring.generate({ length: 72, charset: 'alphanumeric' })
+				}
+
+				return config
+			},
+			(error) => {
+				return Promise.reject(error)
+			},
+		)
 	}
 
 	run(name, params, body) {
@@ -83,31 +109,6 @@ class Endpoints {
 
 	async req(endpoint, body) {
 		let req = await this.createRequest(endpoint, body)
-
-		// Request interceptor
-		this.axiosInstance.interceptors.request.use(
-			async (config) => {
-				if (!this.auth || this.isExpired()) {
-					this.authError = await this.authenticate()
-				}
-
-				config.headers = {
-					Authorization: `Bearer ${this.auth.access_token}`,
-					'x-skip-mtls-checking': !this.options.validateMtls
-				}
-				if (this.options.partner_token) {
-					config.headers['partner-token'] = this.options.partner_token
-				}
-				if (this.baseUrl == this.constants.APIS.OPENFINANCE.URL.PRODUCTION || this.baseUrl == this.constants.APIS.OPENFINANCE.URL.SANDBOX) {
-					config.headers['x-idempotency-key'] = randomstring.generate({ length: 72, charset: 'alphanumeric' })
-				}
-
-				return config
-			},
-			(error) => {
-				Promise.reject(error)
-			},
-		)
 
 		return this.axiosInstance(req)
 			.then((res) => {


### PR DESCRIPTION
 ## Problema

  Ao reutilizar a mesma instância de EfiPay em um servidor Node.js de longa duração,
  os interceptors do `axios` acumulam infinitamente porque `interceptors.request.use()`
  é chamado dentro de `req()` a cada requisição, ao invés de ser registrado uma única vez.

  Corrige [https://github.com/efipay/sdk-node-apis-efi/issues/7](url)

  ## Causa Raiz

  `interceptors.request.use()` em `src/lib/endpoints.js`sendo chamado dentro
  do método `req()` (linha 88), adiciona um novo interceptor a cada chamada de API.

  ## Impacto

  - **Memory leak:** handlers de interceptor crescem indefinidamente
  - **Degradação de performance:** N interceptors executam na requisição N
  - **Potenciais race conditions:** múltiplos interceptors chamando `authenticate()` simultaneamente

  ## Solução

  Mover o registro do interceptor para o constructor, garantindo que seja registrado
  apenas uma vez por instância.

  ## Como Reproduzir (antes do fix)

  1. Criar uma única instância de EfiPay na inicialização do servidor
  2. Reutilizá-la para múltiplas chamadas de API
  3. Logar contagem de interceptors: `this.axiosInstance.interceptors.request.handlers.filter(h => h !== null).length`
  4. Observar contagem crescendo: 0 -> 1 -> 2 -> ... -> N

  ## Workaround 

  Usar `cache: false` nas `options`, ou criar nova instância de EfiPay por requisição.